### PR TITLE
Pin Transformer Lens Dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,8 +72,7 @@ torchaudio==2.0.2
 torchmetrics==1.0.0
 torchvision==0.15.2
 tqdm==4.65.0
-transformer-lens==0.0.0
-transformers==4.30.2
+transformer-lens @ git+https://github.com/neelnanda-io/TransformerLens.git@218ebd6f491f47f5e2f64e4c4327548b60a093ebtransformers==4.30.2
 triton==2.0.0
 typeguard==3.0.2
 typing_extensions==4.7.1


### PR DESCRIPTION
This pins to the latest commit (not the one originally in colab) because it implements a bugfix that also addresses the `names_filter` kwarg issue (see [here](https://github.com/neelnanda-io/TransformerLens/commit/a7728b821e4024dbbdf028533875a95f75ab9bea)). In pip the version number may come out as `transformer-lens==0.0.0` when using `pip list` because this is not an official release but `pip freeze` is what we should use for `requirements.txt` anyways and will capture the commit hash for future updates.

closes #12 