### PR TITLE
Update setup.py to use requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,10 @@
 from setuptools import setup, find_packages
 
-setup(name="attention_lens", version="0.0.1", packages=find_packages())
+with open('requirements.txt') as f:
+    install_requires = f.readlines()
+
+setup(
+  name="attention_lens", 
+  version="0.0.1",
+  install_requires=install_requires,
+  packages=find_packages())


### PR DESCRIPTION
Setup.py to use requirements.txt via install_requires.
Untested changes, so please give this a test before you merge.